### PR TITLE
Update connection parameters

### DIFF
--- a/.github/workflows/tests-files/config.toml
+++ b/.github/workflows/tests-files/config.toml
@@ -2,9 +2,9 @@ default_connection_name = "myconnection"
   
 [connections] 
 [connections.myconnection]
-user = "jorvasquezr"
-warehouse = "COMPUTE_WH"
-database = "mytestdb"
+user = "jovasquez"
+warehouse = "SC_ASGARD_WH"
+database = "DEMO"
 schema = "PUBLIC"
-role = "ACCOUNTADMIN"
-region = "us-east-1"
+role = "SC_ASGARD_ROLE"
+

--- a/.github/workflows/tests-files/config.toml
+++ b/.github/workflows/tests-files/config.toml
@@ -3,8 +3,3 @@ default_connection_name = "myconnection"
 [connections] 
 [connections.myconnection]
 user = "jovasquez"
-warehouse = "SC_ASGARD_WH"
-database = "DEMO"
-schema = "PUBLIC"
-role = "SC_ASGARD_ROLE"
-


### PR DESCRIPTION
The tests was failing because the trial account expired, so I update the connection parameters to a connect to a permanent account. 