### PR TITLE
Update installed package name

### DIFF
--- a/.github/workflows/list-snowflake-account-connections.yml
+++ b/.github/workflows/list-snowflake-account-connections.yml
@@ -25,7 +25,6 @@ jobs:
           uses: ./ 
           id: setup_snowcli
           with:
-            cli-version: '2.1.0'
             default-config-file-path: '.github/workflows/tests-files/config.toml'
 
         - name: Test connection 

--- a/.github/workflows/set-unboud-pipx-variable-test.yml
+++ b/.github/workflows/set-unboud-pipx-variable-test.yml
@@ -25,7 +25,6 @@ jobs:
           uses: ./ 
           id: setup_snowcli
           with:
-            cli-version: '2.1.0'
             default-config-file-path: '.github/workflows/tests-files/config.toml'
 
         - name: Test connection 

--- a/scripts/install-snowcli.sh
+++ b/scripts/install-snowcli.sh
@@ -12,9 +12,9 @@ mkdir -p "${PIPX_BIN_DIR}"
 
 
 if [ "$CLI_VERSION" == "latest" ]; then
-    pipx install snowflake-cli-labs 
+    pipx install snowflake-cli
 else 
-    pipx install snowflake-cli-labs=="$CLI_VERSION"
+    pipx install snowflake-cli=="$CLI_VERSION"
 fi
 
 


### PR DESCRIPTION
This PR changes the package name from `snowflake-cli-labs` to `snowflake-cli`.

Two actions (`list-snowflake-account-connections.yml` and `set-unboud-pipx-variable-test.yml`) were pinned to an old version of snowcli and the runs were failing. I unpinned the package versions in the workflows. If there's a need for testing older versions (the effect of `CLI_VERSION`) -- maybe it can be done through a dedicated workflow?

Fixes #26 